### PR TITLE
Define CMAKE_INSTALL_PREFIX; add setup.fhicl_cpp_standalone.sh

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ project(fhicl_cpp_standalone VERSION ${FHICLCPP_SUITE_VERSION_DOT})
 set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
+#Changes default install path to be a subdirectory of the build dir.
+#Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
+if(CMAKE_INSTALL_PREFIX STREQUAL "" OR CMAKE_INSTALL_PREFIX STREQUAL
+  "/usr/local")
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/${CMAKE_SYSTEM_NAME}")
+elseif(NOT DEFINED CMAKE_INSTALL_PREFIX)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/${CMAKE_SYSTEM_NAME}")
+endif()
+
 #lets use CPM instead of ExternalProject_Add as it plays better with
 #finding existing binary releases.
 # file(
@@ -122,6 +131,10 @@ install(EXPORT fhicl_cpp_standalone-targets
 install(FILES "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfigVersion.cmake"
               "${PROJECT_BINARY_DIR}/fhicl_cpp_standaloneConfig.cmake"
         DESTINATION lib/cmake/fhicl_cpp_standalone)
+configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/Templates/setup.fhicl_cpp_standalone.sh.in 
+  ${PROJECT_BINARY_DIR}/setup.fhicl_cpp_standalone.sh @ONLY)
+install(PROGRAMS ${PROJECT_BINARY_DIR}/setup.fhicl_cpp_standalone.sh DESTINATION bin)
+
 
 
 if(TESTS_ENABLED)

--- a/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
+++ b/cmake/Templates/fhicl_cpp_standaloneConfig.cmake.in
@@ -2,6 +2,8 @@
 
 set(fhicl_cpp_standalone_VERSION @PROJECT_VERSION@)
 
+include(CMakeFindDependencyMacro)
+
 find_dependency(Boost 1.75 COMPONENTS filesystem REQUIRED)
 find_dependency(SQLite3 3 REQUIRED)
 find_dependency(TBB 2020 REQUIRED)

--- a/cmake/Templates/setup.fhicl_cpp_standalone.sh.in
+++ b/cmake/Templates/setup.fhicl_cpp_standalone.sh.in
@@ -1,0 +1,60 @@
+if [ ${BASH_VERSINFO[0]} -le 2 ]; then
+  echo "[ERROR]: You must source this setup script (not run it in a sub-shell). Use like $ source setup.sh"
+  exit 1
+fi
+
+if ! type add_to_PATH &> /dev/null; then
+
+### Adapted from https://unix.stackexchange.com/questions/4965/keep-duplicates-out-of-path-on-source
+function add_to_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/bin" ] || [ "$d" == "/usr/bin64" ] || [ "$d" == "/usr/local/bin" ] || [ "$d" == "/usr/local/bin64" ]; then
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$PATH:$d;;
+      esac
+    else
+      case ":$PATH:" in
+        *":$d:"*) :;;
+        *) export PATH=$d:$PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+if ! type add_to_LD_LIBRARY_PATH &> /dev/null; then
+
+function add_to_LD_LIBRARY_PATH () {
+  for d; do
+
+    d=$(cd -- "$d" && { pwd -P || pwd; }) 2>/dev/null  # canonicalize symbolic links
+    if [ -z "$d" ]; then continue; fi  # skip nonexistent directory
+
+    if [ "$d" == "/usr/lib" ] || [ "$d" == "/usr/lib64" ] || [ "$d" == "/usr/local/lib" ] || [ "$d" == "/usr/local/lib64" ]; then
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$d;;
+      esac
+    else
+      case ":$LD_LIBRARY_PATH:" in
+        *":$d:"*) :;;
+        *) export LD_LIBRARY_PATH=$d:$LD_LIBRARY_PATH;;
+      esac
+    fi
+  done
+}
+
+fi
+
+export fhicl_cpp_standalone_ROOT=@CMAKE_INSTALL_PREFIX@
+export fhicl_cpp_standalone_VERSION=@PROJECT_VERSION@
+
+add_to_PATH "@CMAKE_INSTALL_PREFIX@/bin"
+
+add_to_LD_LIBRARY_PATH "@CMAKE_INSTALL_PREFIX@/lib"


### PR DESCRIPTION
1. Define `CMAKE_INSTALL_PREFIX`
2. Adding `include(CMakeFindDependencyMacro)` to use `find_dependency` macros
3. `setup.fhicl_cpp_standalone.sh` added